### PR TITLE
Initialize FastAPI project

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/ping")
+def ping():
+    return {"msg": "pong"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+pytest>=8


### PR DESCRIPTION
## Summary
- scaffold basic FastAPI app with /ping endpoint
- add requirements file
- keep empty tests directory

## Testing
- `pytest -q`
- `pip install fastapi uvicorn "pytest>=8"` *(fails: Tunnel connection failed 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6840f9cd79b88330a2c882eab9c75438